### PR TITLE
Fix Comments in Unions

### DIFF
--- a/syntaxes/capnp.tmLanguage.json
+++ b/syntaxes/capnp.tmLanguage.json
@@ -311,6 +311,9 @@
 					"patterns": [
 						{
 							"include": "#field"
+						},
+						{
+							"include": "#comment"
 						}
 					],
 					"end": "}",


### PR DESCRIPTION
Hi! I noticed that comments inside of unions are not highlighted properly. This should fix that

<img width="422" height="112" alt="image" src="https://github.com/user-attachments/assets/0a8af590-08b3-407b-b350-e67e12aa873a" />
